### PR TITLE
add remctl_xinetd_service_type to server.pp to work with future parser / strict_variables

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class remctl::params {
       $remctl_xinetd_server         = '/usr/sbin/remctld'
       $remctl_xinetd_server_args    = undef
       $remctl_xinetd_service_name   = 'remctl'
+      $remctl_xinetd_service_type   = undef
       $remctl_xinetd_socket_type    = 'stream'
       $remctl_xinetd_user           = 'root'
       $remctl_xinetd_wait           = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,6 +38,7 @@ class remctl::server (
   $remctl_xinetd_server         = $remctl::params::remctl_xinetd_server,
   $remctl_xinetd_server_args    = $remctl::params::remctl_xinetd_server_args,
   $remctl_xinetd_service_name   = $remctl::params::remctl_xinetd_service_name,
+  $remctl_xinetd_service_type   = $remctl::params::remctl_xinetd_service_type,
   $remctl_xinetd_socket_type    = $remctl::params::remctl_xinetd_socket_type,
   $remctl_xinetd_user           = $remctl::params::remctl_xinetd_user,
   $remctl_xinetd_wait           = $remctl::params::remctl_xinetd_wait,


### PR DESCRIPTION
if we do not add this variable, we get an 
Evaluation Error: Unknown variable: 'remctl::server::remctl_xinetd_service_type'.
in remctl/manifests/server/inetd.pp