### PR TITLE
add remctl_xinetd_service_type to params.pp/server.pp to work with future parser/strict_variables (Debian)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,6 +100,7 @@ class remctl::params {
       $remctl_xinetd_server         = '/usr/sbin/remctld'
       $remctl_xinetd_server_args    = undef
       $remctl_xinetd_service_name   = 'remctl'
+      $remctl_xinetd_service_type   = undef
       $remctl_xinetd_socket_type    = 'stream'
       $remctl_xinetd_user           = 'root'
       $remctl_xinetd_wait           = undef


### PR DESCRIPTION
forgot to add remctl_xinetd_service_type for Debian